### PR TITLE
Remove carbon from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,13 @@
         "ext-phalcon": ">=3.0.0",
         "vlucas/phpdotenv": "^2.0",
         "phalcon/incubator": "~3.0",
-        "nesbot/carbon": "^1.21",
         "baka/database": "dev-master",
         "baka/http": "dev-master"
     },
     "require-dev": {
         "codeception/verify": "*",
         "vlucas/phpdotenv": "^2.0",
-        "phalcon/incubator": "~3.0",
-        "nesbot/carbon": "^1.21"
+        "phalcon/incubator": "~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Carbon isn't used in the package and isn't the last version of it.
So this package is preventing me to update my project dependencies and int even using carbon.